### PR TITLE
Fix floating point error in cart totals

### DIFF
--- a/pages/cart.jsx
+++ b/pages/cart.jsx
@@ -51,10 +51,10 @@ const CartPage = () => {
                   x
                 </button>
               </div>
-              <p>$ {item.quantity * item.price}</p>
+              <p>$ {(item.quantity * item.price).toFixed(2)}</p>
             </div>
           ))}
-          <h2>Grand Total: $ {getTotalPrice()}</h2>
+          <h2>Grand Total: $ {getTotalPrice().toFixed(2)}</h2>
         </>
       )}
     </div>


### PR DESCRIPTION
Add `.toFixed(2)` to the cart's total price and grand total fields to hide extra digits. Example with 5 copies of "Cyberpunk 2077":

Old behaviour: $ 182.45000000000002
New behaviour: $ 182.45